### PR TITLE
forward additional options to httpoison request

### DIFF
--- a/lib/notionex/api/httpoison_client.ex
+++ b/lib/notionex/api/httpoison_client.ex
@@ -4,13 +4,14 @@ defmodule Notionex.API.HTTPoisonClient do
   alias Notionex.API.Request
 
   @impl true
-  def request(%Request{} = request, _opts \\ []) do
+  def request(%Request{} = request, opts \\ %{}) do
     %HTTPoison.Request{
       method: request.method,
       url: request.url,
       body: request.body,
       headers: request.headers,
-      params: request.params
+      params: request.params,
+      options: extract_http_options(opts)
     }
     |> do_request()
     |> case do
@@ -23,7 +24,7 @@ defmodule Notionex.API.HTTPoisonClient do
   end
 
   @impl true
-  def request!(%Request{} = request, opts \\ []) do
+  def request!(%Request{} = request, opts \\ %{}) do
     case request(request, opts) do
       {:ok, response} ->
         response
@@ -45,4 +46,14 @@ defmodule Notionex.API.HTTPoisonClient do
         {:error, "HTTPoison error: #{inspect(resp)}"}
     end
   end
+
+  # Extract HTTP-specific options from the opts map and convert to keyword list for HTTPoison
+  # HTTPoison supports options like timeout, recv_timeout, connect_timeout, etc.
+  defp extract_http_options(opts) when is_map(opts) do
+    opts
+    |> Map.take([:timeout, :recv_timeout, :connect_timeout, :proxy, :proxy_auth, :ssl, :follow_redirect, :max_redirect, :stream_to, :async, :hackney])
+    |> Map.to_list()
+  end
+
+  defp extract_http_options(_opts), do: []
 end


### PR DESCRIPTION
This PR lets you forward options for HTTPoison (I personally needed to forward timeout and recv_timeout), i.e.:

`Notionex.request(%{block_id: parent_block_id}, :retrieve_block_children, %{timeout: 1_000_000, recv_timeout: 1_000_000})`

Not sure if it's an edge case or you'd wan to include it in the library 